### PR TITLE
fixes: quirkinfo.py UnicodeDecodeError for utf-8

### DIFF
--- a/Quirks/quirkinfo.py
+++ b/Quirks/quirkinfo.py
@@ -42,7 +42,7 @@ class QuirkInfo:
         '''
         for item in self._quirk_info.keys():
             try:
-                value = open(os.path.join(self.sys_dir,
+                value = open('UTF-8')(os.path.join(self.sys_dir,
                     'class', 'dmi', 'id', item)).read().strip()
             except (OSError, IOError):
                 value = ''


### PR DESCRIPTION
when configure or purge or uninstall, it will run error with 

```
Traceback (most recent call last):
  File "/usr/bin/quirks-handler", line 65, in <module>
    operation_status = main(options)
  File "/usr/bin/quirks-handler", line 48, in main
    quirks = Quirks.quirkapplier.QuirkChecker(options.package_disable, path=quirks_path)
  File "/usr/lib/python3/dist-packages/Quirks/quirkapplier.py", line 38, in __init__
    self._system_info = self.get_system_info()
  File "/usr/lib/python3/dist-packages/Quirks/quirkapplier.py", line 64, in get_system_info
    return quirk_info.get_dmi_info()
  File "/usr/lib/python3/dist-packages/Quirks/quirkinfo.py", line 46, in get_dmi_info
    'class', 'dmi', 'id', item)).read().strip()
  File "/usr/lib/python3.4/codecs.py", line 313, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
dpkg: error processing package nvidia-331 (--purge):
 子进程 已安装 pre-removal 脚本 return error code 1
```

This commit to fix this
